### PR TITLE
イイネボタン改良

### DIFF
--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -14,7 +14,7 @@ class StoriesController < ApplicationController
     @story.like_count = 0 if @story.like_count.nil?
     @story.like_count += 1
     @story.save
-    redirect_to stories_url
+    redirect_to 'show'
   end
 
   def show

--- a/app/controllers/stories_controller.rb
+++ b/app/controllers/stories_controller.rb
@@ -14,7 +14,7 @@ class StoriesController < ApplicationController
     @story.like_count = 0 if @story.like_count.nil?
     @story.like_count += 1
     @story.save
-    redirect_to 'show'
+    redirect_to @story
   end
 
   def show

--- a/app/views/stories/index.html.erb
+++ b/app/views/stories/index.html.erb
@@ -68,7 +68,7 @@
       <tr>
 
 
-<%= link_to "いいね", story_like_path(story), method: :patch, remote: true %>
+<!--<%= link_to "いいね", story_like_path(story), method: :patch, remote: true %> -->
 <%= story.like_count %>
         <td colspan="3"><%= truncate(simple_format(story.content), length: 160, escape: false) %><br><%= link_to 'もっと見る', story, :class => 'btn btn-success pull-right' %></td>
         <!--<td><%= link_to 'Edit', edit_story_path(story) %></td>

--- a/app/views/stories/show.html.erb
+++ b/app/views/stories/show.html.erb
@@ -3,6 +3,9 @@
 <h1>体験談詳細</h1>
 <!-- <% params["department_select"] = @story.department.name %> -->
 
+<%= link_to "いいね", story_like_path(@story), method: :patch, remote: true %>
+<%= @story.like_count %>
+
 <table class="table table-bordered" width="60%">
   <col width="15%">
   <col width="45%">


### PR DESCRIPTION
一覧ではいいねボタンを押せず、いいね数のみを表示
詳細ページでいいねボタンが押せて、いいね数も表示される
しかし、詳細ページでいいねボタンを押しても、一度ページをロードするまでいいね数は変わらない